### PR TITLE
add: 홈 화면 기본 레이아웃 추가

### DIFF
--- a/app.go
+++ b/app.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyungseopk1m/env-tools/app/env"
 	"github.com/kyungseopk1m/env-tools/app/models"
 	"github.com/kyungseopk1m/env-tools/app/storage"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 	// "github.com/wailsapp/wails/v2/pkg/menu"
 	// "github.com/wailsapp/wails/v2/pkg/menu/keys"
 )
@@ -28,8 +29,31 @@ func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 }
 
+// OpenFileDialog opens a file dialog and returns the selected file path
+func (a *App) OpenFileDialog() (string, error) {
+	dialog, err := runtime.OpenFileDialog(a.ctx, runtime.OpenDialogOptions{
+		Title: "ENV 파일 선택",
+		Filters: []runtime.FileFilter{
+			{
+				DisplayName: "ENV 파일 (*.env)",
+				Pattern:     "*.env",
+			},
+			{
+				DisplayName: "모든 파일 (*.*)",
+				Pattern:     "*.*",
+			},
+		},
+	})
+
+	return dialog, err
+}
+
 // LoadEnvFile loads and parses a .env file
 func (a *App) LoadEnvFile(filePath string) ([]models.EnvVariable, error) {
+	if filePath == "" {
+		return nil, fmt.Errorf("file path is empty")
+	}
+
 	variables, err := env.ParseEnvFile(filePath)
 	if err != nil {
 		fmt.Printf("Error loading .env file: %v\n", err)
@@ -51,38 +75,38 @@ func (a *App) SaveEnvFile(filePath string, variables []models.EnvVariable) error
 // createMenu creates the application menu
 // func (a *App) createMenu() *menu.Menu {
 // 	appMenu := menu.NewMenu()
-	
+
 // 	fileMenu := appMenu.AddSubmenu("File")
 // 	fileMenu.AddText("Open", keys.CmdOrCtrl("o"), func(_ *menu.CallbackData) {})
 // 	fileMenu.AddText("Save", keys.CmdOrCtrl("s"), func(_ *menu.CallbackData) {})
-	
+
 // 	return appMenu
 // }
 
 func (a *App) AddToHistory(filePath string, description string) error {
-    histories, err := storage.LoadHistory()
-    if err != nil {
-        return err
-    }
+	histories, err := storage.LoadHistory()
+	if err != nil {
+		return err
+	}
 
-    newHistory := models.EnvHistory{
-        FilePath:    filePath,
-        LastOpened:  time.Now(),
-        Description: description,
-    }
+	newHistory := models.EnvHistory{
+		FilePath:    filePath,
+		LastOpened:  time.Now(),
+		Description: description,
+	}
 
-    // 중복 항목 제거
-    for i, h := range histories {
-        if h.FilePath == filePath {
-            histories = append(histories[:i], histories[i+1:]...)
-            break
-        }
-    }
+	// 중복 항목 제거
+	for i, h := range histories {
+		if h.FilePath == filePath {
+			histories = append(histories[:i], histories[i+1:]...)
+			break
+		}
+	}
 
-    histories = append([]models.EnvHistory{newHistory}, histories...)
-    return storage.SaveHistory(histories)
+	histories = append([]models.EnvHistory{newHistory}, histories...)
+	return storage.SaveHistory(histories)
 }
 
 func (a *App) GetHistory() ([]models.EnvHistory, error) {
-    return storage.LoadHistory()
+	return storage.LoadHistory()
 }

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,187 @@
+/*=============================================
+=                Base Layout                 =
+=============================================*/
+
+/* 메인 컨테이너 - 전체 앱을 감싸는 최상위 컨테이너 */
+.app-container {
+  display: flex;
+  height: 100vh;
+  background-color: #ffffff;
+  overflow: hidden;
+}
+
+/*=============================================
+=                 Sidebar                    =
+=============================================*/
+
+/* 사이드바 - 좌측 메뉴 영역 */
+.sidebar {
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100vh;
+  width: 200px;
+  background-color: #f5f5f5;
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 사이드바 상태 - 열림/닫힘 */
+.sidebar.closed {
+  transform: translateX(-200px);
+}
+
+.sidebar.open {
+  transform: translateX(0);
+}
+
+/* 메뉴 탭 영역 */
+.menu-tabs {
+  padding: 0;
+  border-bottom: 1px solid #e0e0e0;
+}
+
+.menu-tab {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  user-select: none;
+}
+
+.menu-tab.active {
+  background-color: #e0e0e0;
+  font-weight: 500;
+}
+
+.menu-tab:hover:not(.active) {
+  background-color: #eaeaea;
+}
+
+/* 파일 액션 버튼 영역 */
+.file-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 24px;
+}
+
+.file-actions button {
+  width: 100%;
+  padding: 8px 12px;
+  background-color: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: center;
+  transition: background-color 0.2s ease;
+}
+
+.file-actions button:hover {
+  background-color: #0056b3;
+}
+
+/*=============================================
+=              Main Content                  =
+=============================================*/
+
+/* 메인 컨텐츠 영역 */
+.main-content {
+  flex: 1;
+  margin-left: 200px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.main-content.expanded {
+  margin-left: 0;
+}
+
+/* 헤더 영역 */
+.content-header {
+  width: 100%;
+  height: 43px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 18px;
+  font-weight: 500;
+  color: #333;
+  box-sizing: border-box;
+}
+
+/*=============================================
+=              ENV List Area                 =
+=============================================*/
+
+/* ENV 변수 리스트 영역 */
+.env-list {
+  flex: 1;
+  width: 100%;
+  overflow-y: auto;
+  padding: 0 16px;
+}
+
+.env-item {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  width: 100%;
+}
+
+.env-item input {
+  padding: 8px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+.env-item input:first-child {
+  width: 40%;
+}
+
+.env-item input:last-child {
+  width: 60%;
+}
+
+/*=============================================
+=                Help Button                 =
+=============================================*/
+
+/* 우측 하단 도움말 버튼 */
+.help-button {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #007AFF;
+  color: white;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.help-button:hover {
+  background: #0056b3;
+}
+
 /* Container */
 .app-container {
   display: flex;
@@ -96,7 +280,7 @@
 
 .content-header {
   width: 100%;
-  height: 50px;
+  height: 43px;
   display: flex;
   align-items: center;
   padding: 0 20px;
@@ -148,4 +332,95 @@
 
 .env-item input:last-child {
   width: 60%;
+}
+
+/* 컨텐츠 본문 영역 */
+.content-body {
+  flex: 1;
+  padding: 40px;
+  overflow-y: auto;
+  background-color: #ffffff;
+}
+
+.home-actions {
+  display: flex;
+  gap: 16px;
+  margin-top: 40px;
+  margin-bottom: 32px;
+  width: 100%;
+  justify-content: center;
+}
+
+.action-button {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.action-button:hover {
+  background: #f5f5f5;
+  transform: translateY(-2px);
+}
+
+.action-icon {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+.recent-files {
+  margin-top: 32px;
+  padding: 24px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  width: 90%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.recent-files h3 {
+  margin: 0 0 16px 0;
+  font-size: 16px;
+  color: #333;
+  text-align: left;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.history-item {
+  display: flex;
+  align-items: center;
+  padding: 12px;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.history-item:hover {
+  background: #f5f5f5;
+}
+
+.history-icon {
+  margin-right: 12px;
+  font-size: 20px;
+}
+
+.history-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.history-date {
+  font-size: 12px;
+  color: #666;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react'
 import './App.css'
-import { LoadEnvFile, SaveEnvFile, GetHistory, AddToHistory } from '../wailsjs/go/main/App'
+import { LoadEnvFile, SaveEnvFile, GetHistory, AddToHistory, OpenFileDialog } from '../wailsjs/go/main/App'
 import { EventsOn } from '../wailsjs/runtime'
 import { EnvList } from './components/EnvList'
 import { EnvHistory, EnvVariable } from './models'
 import { WindowSetTitle } from '../wailsjs/runtime/runtime'
+import { Home } from './components/Home'
 
 function App() {
   const [activeTab, setActiveTab] = useState('home');
@@ -38,14 +39,14 @@ useEffect(() => {
 
   const handleFileOpen = async () => {
     try {
-        const result = await LoadEnvFile('.env');
+        const filePath = await OpenFileDialog();
+        if (!filePath) return;  // 사용자가 취소한 경우
+
+        const result = await LoadEnvFile(filePath);
         setVariables(result);
-        setCurrentFile('.env'); // 현재 파일 경로 저장
+        setCurrentFile(filePath);
         
-        // 파일을 열 때마다 히스토리에 추가
-        await AddToHistory('.env', '환경 변수 파일'); // 백엔드에 히스토리 저장
-        
-        // 히스토리 상태 업데이트를 위해 다시 로드
+        await AddToHistory(filePath, '환경 변수 파일');
         const updatedHistory = await GetHistory();
         setHistory(updatedHistory);
     } catch (err) {
@@ -92,10 +93,6 @@ useEffect(() => {
             </div>
           ))}
         </div>
-        <div className="file-actions">
-          <button onClick={handleFileOpen}>파일 열기</button>
-          <button onClick={handleSave}>저장</button>
-        </div>
         <div className="file-info">
           {currentFile && <p>현재 파일: {currentFile}</p>}
         </div>
@@ -105,17 +102,28 @@ useEffect(() => {
         <div className="content-header">
           {menuTabs.find(tab => tab.id === activeTab)?.name}
         </div>
-        <div className="search-bar">
-          <input type="text" placeholder="환경 변수 검색..." />
-        </div>
-        <div className="env-list">
-          {variables.map((variable, index) => (
-            <div key={index} className="env-item">
-              <input value={variable.key} />
-              <input value={variable.value} />
+        
+        {activeTab === 'home' ? (
+          <Home 
+            onImport={handleFileOpen}
+            onNewFile={() => {/* 새 파일 생성 로직 */}}
+            recentHistory={history}
+          />
+        ) : (
+          <>
+            <div className="search-bar">
+              <input type="text" placeholder="환경 변수 검색..." />
             </div>
-          ))}
-        </div>
+            <div className="env-list">
+              {variables.map((variable, index) => (
+                <div key={index} className="env-item">
+                  <input value={variable.key} />
+                  <input value={variable.value} />
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { EnvHistory } from '../models';
+
+interface HomeProps {
+  onImport: () => void;
+  onNewFile: () => void;
+  recentHistory: EnvHistory[];
+}
+
+export const Home: React.FC<HomeProps> = ({ onImport, onNewFile, recentHistory }) => {
+  return (
+    <div className="content-body">
+      <div className="home-actions">
+        <button className="action-button" onClick={onImport}>
+          <span className="action-icon">📂</span>
+          <span>불러오기</span>
+        </button>
+        <button className="action-button" onClick={onNewFile}>
+          <span className="action-icon">📄</span>
+          <span>새 파일</span>
+        </button>
+      </div>
+      
+      <div className="recent-files">
+        <h3>최근 폴더 목록</h3>
+        <div className="history-list">
+          {recentHistory.map((item, index) => (
+            <div key={index} className="history-item">
+              <span className="history-icon">📁</span>
+              <div className="history-details">
+                <span className="history-path">{item.filePath}</span>
+                <span className="history-date">
+                  {new Date(item.lastOpened).toLocaleDateString()}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      
+      <button className="help-button">
+        <span>?</span>
+      </button>
+    </div>
+  );
+};


### PR DESCRIPTION
## 작업 상세 내용
  - 와이어프레임에 표시된 간단한 `<불러오기>, <새파일>, <최근 폴더 목록>, <도움말>` 버튼을 추가했습니다.
  - 참고용으로 사용할 레이아웃으로 보시면 되고, 추후 디자인과 서버쪽 코드가 완성되면 수정할 예정입니다.
  - 테스트를 위해 app.go 파일 내 `OpenFileDialog`와 같은 함수를 추가했습니다.

## 스크린샷 (선택)
<img width="992" alt="스크린샷 2025-01-30 21 54 31" src="https://github.com/user-attachments/assets/a91cc8b1-f618-4267-bbc6-9dfb5ada3f7b" />
<img width="992" alt="스크린샷 2025-01-30 21 55 10" src="https://github.com/user-attachments/assets/9f1d7f5c-6601-4e56-948b-209dd832d471" />

## 리뷰 요구사항 및 특이사항
  - app.go 파일로 인해 충돌이 날 가능성이 있습니다. 유의해서 PR 올려주세요. 제가 app.go에 작성한 기존 코드는 날리셔도 됩니다.
  - 2월부터는 협업할 일이 많을 거 같은데, 서로 작업한 내용에 대한 task 관리를 따로 해야될 거 같습니다. 깃헙 프로젝트 내에 kanban 형태로 만들고자하니 공유 후 다시 말씀 드리겠습니다.